### PR TITLE
fix watchOS < 6.0 crash with Xcode 11

### DIFF
--- a/EMTLoadingIndicator.podspec
+++ b/EMTLoadingIndicator.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/hirokimu/EMTLoadingIndicator.git", :tag => s.version }
   s.watchos.source_files = "EMTLoadingIndicator/Classes/*.swift"
   s.watchos.resources = "EMTLoadingIndicator/Resources/*.png"
-  s.frameworks = "WatchKit", "UIKit"
+  s.frameworks = "UIKit"
   s.requires_arc = true
 end


### PR DESCRIPTION
WatchOS 4 & WatchOS 5 now crashing with your pod. This is a bug of new Xcode 11. I found solution for fix this issue. 